### PR TITLE
successfully adding trips to storage via API

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -50,24 +50,24 @@ const Form = props => {
 
   const API_SERVER = 'https://adventures-back-end-jessi.herokuapp.com' || 'http://localhost:3002';
 
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [anchorElState, setAnchorElState] = React.useState(null);
 
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
+  const handleClickState = (event) => {
+    setAnchorElState(event.currentTarget);
   };
 
-  const handleClose = () => {
-    setAnchorEl(null);
+  const handleCloseState = () => {
+    setAnchorElState(null);
   };
 
-  const [anchorEl2, setAnchorEl2] = React.useState(null);
+  const [anchorElActivity, setAnchorElActivity] = React.useState(null);
 
-  const handleClick2 = (event) => {
-    setAnchorEl2(event.currentTarget);
+  const handleClickActivity = (event) => {
+    setAnchorElActivity(event.currentTarget);
   };
 
-  const handleClose2 = () => {
-    setAnchorEl2(null);
+  const handleCloseActivity = () => {
+    setAnchorElActivity(null);
   };
 
   const [activityList, setActivityList] = useState([]);
@@ -91,40 +91,40 @@ const Form = props => {
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
         <Card className={classes.form}>
-          <Button className={classes.stateMenu} aria-controls='simple-menu' aria-haspopup='true' onClick={handleClick}>
+          <Button className={classes.stateMenu} aria-controls='simple-menu' aria-haspopup='true' onClick={handleClickState}>
             Search By State
           </Button>
           <Menu
             id='simple-menu'
-            anchorEl={anchorEl}
+            anchorEl={anchorElState}
             keepMounted
-            open={Boolean(anchorEl)}
-            onClose={handleClose}
+            open={Boolean(anchorElState)}
+            onClose={handleCloseState}
           >
           {props.stateCodeReducer.stateCodes.map((stateCode, idx) => {
             return (
               <MenuItem key={idx} onClick={() => {
                 props.changeStateCode(stateCode.stateCode); //sets state of activeStateCode upon click
-                setAnchorEl(null); //closes menu upon click
+                setAnchorElState(null); //closes menu upon click
               }}>{stateCode.fullName}</MenuItem>
             )
           })}
           </Menu>
-          <Button className={classes.stateMenu} aria-controls='simple-menu-act' aria-haspopup='true' onClick={handleClick2}>
+          <Button className={classes.stateMenu} aria-controls='simple-menu-act' aria-haspopup='true' onClick={handleClickActivity}>
             Search By Activity
           </Button>
           <Menu
             id='simple-menu-act'
-            anchorEl={anchorEl2}
+            anchorEl={anchorElActivity}
             keepMounted
-            open={Boolean(anchorEl2)}
-            onClose={handleClose2}
+            open={Boolean(anchorElActivity)}
+            onClose={handleCloseActivity}
           >
           {activityList.map((activity, idx) => {
             return (
               <MenuItem key={idx} onClick={() => {
                 props.selectActivity(activity.id);
-                setAnchorEl2(null);
+                setAnchorElActivity(null);
               }}>
                 {activity.name}
               </MenuItem>

--- a/src/components/parks.js
+++ b/src/components/parks.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
+import { useAuth0 } from "@auth0/auth0-react";
 import superagent from 'superagent';
 import { changeStateCode, changeFullName, reset } from '../store/stateCodes.js';
 import { selectPark } from '../store/parkCodes.js';
@@ -9,7 +10,7 @@ import { adaptV4Theme } from '@mui/material/styles';
 import { makeStyles } from '@mui/styles';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import CardMedia from '@mui/material/CardMedia';
+import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import { ThemeProvider, StyledEngineProvider, createTheme } from '@mui/material/styles';
@@ -23,7 +24,8 @@ const theme = createTheme(adaptV4Theme({
     ].join(','),
   },}));
 
-const API_SERVER = 'https://adventures-back-end-jessi.herokuapp.com' || 'http://localhost:3002';
+// const API_SERVER = 'https://adventures-back-end-jessi.herokuapp.com' || 'http://localhost:3002';
+const API_SERVER = 'http://localhost:3002';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -36,7 +38,7 @@ const useStyles = makeStyles((theme) => ({
     color: 'white',
     display: 'inline-block',
     width: 220,
-    height: 260,
+    height: 300,
     margin: 10,
     borderWidth: 1.5,
     borderColor: 'gray',
@@ -52,20 +54,29 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center', 
     justifyContent:'center'
   },
+  addTripButton: {
+    background: '#0e1721',
+    color: '#e0dfdc',
+    borderWidth: 1,
+    borderColor: '#ae6754',
+    borderStyle: 'solid',
+    margin: 10,
+    fontSize: 18,
+  },
 }));
 
 const Parks = props => {
   const classes = useStyles();
+  const { user } = useAuth0();
 
-  //-------State Items-------------\\
+  // ------- State Items ------------- \\
+
   let selectedState = props.stateCodeReducer.activeStateCode;
   let selectedActivity = props.actReducer.selectedActivity;
-  console.log('selected ACT', selectedActivity);
-  console.log('selected STATE', selectedState);
-  // let selectedStateFullName = props.stateCodeReducer.activeStateFullName;
-  // let activePark = props.parkCodeReducer.activeParkCode;
 
   const [parkList, setParkList] = useState([]);
+
+  // ---------- Reactive effect hooks ----------- \\
 
   const useSelectedState = () => {
     useEffect(() => {
@@ -102,6 +113,22 @@ const Parks = props => {
   useSelectedState();
   useSelectedActivity();
 
+  // ------------- Methods ---------------- \\
+
+  const addTrip = (user, park) => {
+    const URL = `${API_SERVER}/trips`
+      superagent
+        .post(URL)
+        .send({ user, park })
+        .then(response => {
+          console.log('success', response);
+        })
+        .catch((err) => {
+          console.log('error: ', err);
+        })
+  }
+
+
   return (
     <Container className={classes.root}>
       {parkList.map((park, idx) => {
@@ -137,6 +164,14 @@ const Parks = props => {
                     </Typography>
                   }
                   </NavLink>
+                  <Button
+                    className={classes.addTripButton}
+                    aria-controls='simple-menu-act'
+                    aria-haspopup='true' 
+                    onClick={() => addTrip(user, park)}
+                  >
+                    Add Trip!
+                  </Button>
                 </CardContent>
               </Card>
             </ThemeProvider>

--- a/src/components/profile.js
+++ b/src/components/profile.js
@@ -54,10 +54,6 @@ const Profile = (props) => {
   const { user, isAuthenticated, isLoading } = useAuth0();
   console.log(user);
 
-  // if (isLoading) {
-  //   return <div>Loading...</div>
-  // }
-
   return isAuthenticated && (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>


### PR DESCRIPTION
This PR introduces the ability to add trips to Mongo storage via the API. For now, each trip is an object with a user and park. 

Coming next: 
1. Confirmation display of trip added (modal?).
2. Display of user's trips on the user profile page (first iteration will probably be cards similar to the parks display)
3. Date picker modal when clicking 'Add Trip' that allows the user to select their dates for that trip (back end schema needs to update too).
4. Individual 'Trip' page accessed from clicking a trip card on the user profile page. Here we can add activities, lodging, camping, etc for that trip.